### PR TITLE
Expose DeviceDetector instance

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -10,11 +10,6 @@ services:
         tags:
             - { name: twig.extension }
 
-    crossknowledge.device_detector:
-        class: CrossKnowledge\DeviceDetectBundle\Services\DeviceDetect
-        arguments: ["@request_stack", "@crossknowledge.default_cache_manager"]
-
-
     crossknowledge.device_detect:
         class: CrossKnowledge\DeviceDetectBundle\Services\DeviceDetect
         arguments: ["@request_stack", "@crossknowledge.default_cache_manager"]

--- a/Services/DeviceDetect.php
+++ b/Services/DeviceDetect.php
@@ -73,4 +73,9 @@ class DeviceDetect
     {
         $this->deviceDetectorOptions = $deviceDetectorOptions;
     }
+
+    public function getDeviceDetector()
+    {
+        return $this->deviceDetector;
+    }
 }


### PR DESCRIPTION
Today the bundle does not expose the `DeviceDetector` instance. It's fixed.
