### PR TITLE
[CKLS-11591] Make device_detect service public

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -15,5 +15,6 @@ services:
             - { name: twig.extension }
 
     crossknowledge.device_detect:
+        public: true
         class: CrossKnowledge\DeviceDetectBundle\Services\DeviceDetect
         arguments: ["@request_stack", "@crossknowledge.default_cache_manager_bridge"]


### PR DESCRIPTION
Currently, we have get those depreciation warning when we try to access the service at runtime :
```
The "crossknowledge.device_detect" service is private, replacing it is deprecated since Symfony 3.2 and will fail in 4.0.
```

This change will allow to access the service directly at runtime once we migrate to Symfony 4.
